### PR TITLE
set instanceid explicitly for secretstorages

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,7 +37,7 @@ func UninitializedSecretStorage(ctx context.Context, args *CommonCliArgs) (secre
 	case VaultTokenStorage:
 		storage, errStorage = vaultcli.CreateVaultStorage(ctx, &args.VaultCliArgs)
 	case AWSTokenStorage:
-		storage, errStorage = awscli.NewAwsSecretStorage(ctx, &args.AWSCliArgs)
+		storage, errStorage = awscli.NewAwsSecretStorage(ctx, args.SPIInstanceId, &args.AWSCliArgs)
 	default:
 		return nil, fmt.Errorf("%w '%s'", errUnsupportedSecretStorage, args.TokenStorage)
 	}

--- a/integration_tests/tokenstorage_acceptance_test.go
+++ b/integration_tests/tokenstorage_acceptance_test.go
@@ -82,7 +82,7 @@ func TestAws(t *testing.T) {
 		return
 	}
 
-	storage, error := tokenstorage.NewAwsTokenStorage(ctx, &awscli.AWSCliArgs{
+	storage, error := tokenstorage.NewAwsTokenStorage(ctx, "spi-test", &awscli.AWSCliArgs{
 		ConfigFile:      awsConfig,
 		CredentialsFile: awsCreds,
 	})

--- a/pkg/spi-shared/secretstorage/awsstorage/aws_test.go
+++ b/pkg/spi-shared/secretstorage/awsstorage/aws_test.go
@@ -23,7 +23,6 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,8 +49,10 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestInitSecretNameFormat(t *testing.T) {
-	ctx := context.WithValue(context.TODO(), config.SPIInstanceIdContextKey, "blabol")
-	assert.Contains(t, initSecretNameFormat(ctx), "blabol")
+	s := AwsSecretStorage{
+		SpiInstanceId: "blabol",
+	}
+	assert.Contains(t, s.initSecretNameFormat(), "blabol")
 }
 
 func TestGenerateSecretName(t *testing.T) {

--- a/pkg/spi-shared/secretstorage/awsstorage/awscli/cli.go
+++ b/pkg/spi-shared/secretstorage/awsstorage/awscli/cli.go
@@ -38,7 +38,7 @@ var (
 	errInvalidCliArgs = errors.New("invalid cli args")
 )
 
-func NewAwsSecretStorage(ctx context.Context, args *AWSCliArgs) (secretstorage.SecretStorage, error) {
+func NewAwsSecretStorage(ctx context.Context, spiInstanceId string, args *AWSCliArgs) (secretstorage.SecretStorage, error) {
 	log.FromContext(ctx).Info("creating aws client")
 	cfg, err := configFromCliArgs(ctx, args)
 	if err != nil {
@@ -46,7 +46,8 @@ func NewAwsSecretStorage(ctx context.Context, args *AWSCliArgs) (secretstorage.S
 	}
 
 	return &awsstorage.AwsSecretStorage{
-		Config: cfg,
+		Config:        cfg,
+		SpiInstanceId: spiInstanceId,
 	}, nil
 }
 

--- a/pkg/spi-shared/secretstorage/awsstorage/awscli/cli_test.go
+++ b/pkg/spi-shared/secretstorage/awsstorage/awscli/cli_test.go
@@ -31,14 +31,14 @@ func TestNewAwsSecretStorage(t *testing.T) {
 	credsFile := createFile(t, "awscreds", "")
 	defer os.Remove(credsFile)
 
-	storage, err := NewAwsSecretStorage(context.TODO(), &AWSCliArgs{ConfigFile: configFile, CredentialsFile: credsFile})
+	storage, err := NewAwsSecretStorage(context.TODO(), "spi-test", &AWSCliArgs{ConfigFile: configFile, CredentialsFile: credsFile})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, storage)
 }
 
 func TestNewAwsSecretStorageWithInvalidConfig(t *testing.T) {
-	storage, err := NewAwsSecretStorage(context.TODO(), &AWSCliArgs{})
+	storage, err := NewAwsSecretStorage(context.TODO(), "spi-test", &AWSCliArgs{})
 
 	assert.Error(t, err)
 	assert.Nil(t, storage)

--- a/pkg/spi-shared/tokenstorage/aws.go
+++ b/pkg/spi-shared/tokenstorage/aws.go
@@ -21,8 +21,8 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/awsstorage/awscli"
 )
 
-func NewAwsTokenStorage(ctx context.Context, args *awscli.AWSCliArgs) (TokenStorage, error) {
-	secretStorage, err := awscli.NewAwsSecretStorage(ctx, args)
+func NewAwsTokenStorage(ctx context.Context, spiInstanceId string, args *awscli.AWSCliArgs) (TokenStorage, error) {
+	secretStorage, err := awscli.NewAwsSecretStorage(ctx, spiInstanceId, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct AWS secret storage: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?
fix setting aws secret name format with explicitly passing spi instance id.

This is just to make it working, I may rework it more and make it cleaner in scope of https://issues.redhat.com/browse/SVPI-449

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-428

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
deploy with AWS, create some token, upload and check that secret is created.